### PR TITLE
Introduce central config loader

### DIFF
--- a/analyze_candidates.py
+++ b/analyze_candidates.py
@@ -11,6 +11,7 @@ This script does not perform MCMC H0 estimation.
 import os
 import sys
 import logging
+from gwsiren import CONFIG
 import numpy as np
 import pandas as pd
 
@@ -30,9 +31,7 @@ try:
         generate_sky_map_and_credible_region,
         select_galaxies_in_sky_region,
         filter_galaxies_by_redshift,
-        estimate_event_specific_z_max,
-        DEFAULT_NSIDE_SKYMAP as MODULE_DEFAULT_NSIDE_SKYMAP,
-        DEFAULT_PROB_THRESHOLD_CDF as MODULE_DEFAULT_PROB_THRESHOLD_CDF
+        estimate_event_specific_z_max
     )
 except ImportError as e:
     print(f"Error importing project modules: {e}")
@@ -58,8 +57,8 @@ CANDIDATE_LIST = [
 
 OUTPUT_DIR = "output_candidate_analysis" # Define a specific output directory for this script
 VIZ_CATALOG_TYPE = 'glade+'
-VIZ_NSIDE_SKYMAP = MODULE_DEFAULT_NSIDE_SKYMAP
-VIZ_PROB_THRESHOLD_CDF = MODULE_DEFAULT_PROB_THRESHOLD_CDF
+VIZ_NSIDE_SKYMAP = CONFIG.skymap["default_nside"]
+VIZ_PROB_THRESHOLD_CDF = CONFIG.skymap["credible_level"]
 VIZ_HOST_Z_MAX_FALLBACK = 0.05
 VIZ_GALAXY_CORRECTIONS = DEFAULT_GALAXY_CORRECTIONS # Use defaults from galaxy_catalog_handler
 

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,8 @@ skymap:
 
 mcmc:
   walkers:         32
-  steps:           6000
-  burnin:          1000
+  steps:           2000
+  burnin:          100
   thin_by:         10
   prior_h0_min:    10.0
   prior_h0_max:    200.0

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,21 @@
+catalog:
+  glade_plus_url:  http://elysium.elte.hu/~dalyag/GLADE+.txt
+  glade24_url:     https://glade.elte.hu/GLADE-2.4.txt
+  data_dir:        data/
+
+skymap:
+  default_nside:   128
+  credible_level:  0.90
+
+mcmc:
+  walkers:         32
+  steps:           6000
+  burnin:          1000
+  thin_by:         10
+  prior_h0_min:    10.0
+  prior_h0_max:    200.0
+
+cosmology:
+  sigma_v_pec:     250.0
+  c_light:         299792.458
+  omega_m:         0.31

--- a/galaxy_catalog_handler.py
+++ b/galaxy_catalog_handler.py
@@ -3,16 +3,17 @@ import sys
 import urllib.request
 import pandas as pd
 import logging
+from gwsiren import CONFIG
 
 logger = logging.getLogger(__name__)
 
-# --- Data Directory ---
-DATA_DIR = "data"
+# --- Data Directory from central config ---
+DATA_DIR = CONFIG.catalog["data_dir"]
 
 # --- Catalog Configurations ---
 CATALOG_CONFIGS = {
     'glade+': {
-        'url': "http://elysium.elte.hu/~dalyag/GLADE+.txt",
+        'url': CONFIG.catalog['glade_plus_url'],
         'filename': "GLADE+.txt",
         'use_cols': [1, 8, 9, 27],  # PGC(col 2), RA(col 9), Dec(col 10), z_helio(col 28) -> 0-indexed
         'col_names': ['PGC', 'ra', 'dec', 'z'], # Standardized names
@@ -20,7 +21,7 @@ CATALOG_CONFIGS = {
         'display_name': "GLADE+"
     },
     'glade24': {
-        'url': "https://glade.elte.hu/GLADE-2.4.txt",
+        'url': CONFIG.catalog['glade24_url'],
         'filename': "GLADE_2.4.txt",
         'use_cols': [0, 6, 7, 15],  # PGC, RA, Dec, z for GLADE 2.4
         'col_names': ['PGC', 'ra', 'dec', 'z'], # Standardized names

--- a/gwsiren/__init__.py
+++ b/gwsiren/__init__.py
@@ -1,0 +1,3 @@
+from .config import Config, load_config, CONFIG
+
+__all__ = ["Config", "load_config", "CONFIG"]

--- a/gwsiren/config.py
+++ b/gwsiren/config.py
@@ -49,7 +49,17 @@ class Config:
 
 
 def load_config(path: str | pathlib.Path | None = None) -> Config:
-    cfg_path = pathlib.Path(path or __file__).with_name('config.yaml')
+    """Load configuration from YAML file.
+    
+    Args:
+        path: Path to config file. If None, looks for config.yaml in root directory.
+    """
+    if path is None:
+        # Look for config.yaml in root directory (parent of gwsiren package)
+        cfg_path = pathlib.Path(__file__).parent.parent / 'config.yaml'
+    else:
+        cfg_path = pathlib.Path(path)
+        
     if not cfg_path.exists():
         raise RuntimeError(f'Config file not found: {cfg_path}')
     text = cfg_path.read_text()

--- a/gwsiren/config.py
+++ b/gwsiren/config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import pathlib
+
+# Try to import PyYAML, fall back to a very small parser if unavailable
+try:
+    import yaml as _pyyaml  # type: ignore
+except Exception:  # pragma: no cover - fallback if PyYAML missing
+    _pyyaml = None
+
+
+def _minimal_yaml_load(text: str) -> dict:
+    """Very small YAML loader supporting two-level mappings."""
+    data: dict[str, dict[str, object]] = {}
+    current = None
+    for raw_line in text.splitlines():
+        line = raw_line.split('#', 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if not line.startswith(' '):
+            key = line.rstrip(':').strip()
+            data[key] = {}
+            current = data[key]
+        else:
+            if current is None:
+                raise ValueError('Invalid YAML structure')
+            sub_key, value = line.strip().split(':', 1)
+            value = value.strip()
+            if value == '':
+                val_obj: object = None
+            else:
+                try:
+                    val_obj = int(value)
+                except ValueError:
+                    try:
+                        val_obj = float(value)
+                    except ValueError:
+                        val_obj = value
+            current[sub_key] = val_obj
+    return data
+
+
+@dataclass(frozen=True)
+class Config:
+    catalog: dict
+    skymap: dict
+    mcmc: dict
+    cosmology: dict
+
+
+def load_config(path: str | pathlib.Path | None = None) -> Config:
+    cfg_path = pathlib.Path(path or __file__).with_name('config.yaml')
+    if not cfg_path.exists():
+        raise RuntimeError(f'Config file not found: {cfg_path}')
+    text = cfg_path.read_text()
+    if _pyyaml is not None:
+        raw = _pyyaml.safe_load(text)
+    else:
+        raw = _minimal_yaml_load(text)
+    return Config(**raw)
+
+
+CONFIG = load_config()

--- a/h0_mcmc_analyzer.py
+++ b/h0_mcmc_analyzer.py
@@ -8,24 +8,25 @@ import logging
 import cProfile
 import pstats
 import io
+from gwsiren import CONFIG
 
 logger = logging.getLogger(__name__)
 
 # Default Cosmological Parameters for Likelihood
-DEFAULT_SIGMA_V_PEC = 250.0  # km/s, peculiar velocity uncertainty
-DEFAULT_C_LIGHT = 299792.458 # km/s
-DEFAULT_OMEGA_M = 0.31
+DEFAULT_SIGMA_V_PEC = CONFIG.cosmology["sigma_v_pec"]  # km/s, peculiar velocity uncertainty
+DEFAULT_C_LIGHT = CONFIG.cosmology["c_light"]
+DEFAULT_OMEGA_M = CONFIG.cosmology["omega_m"]
 
 # Default MCMC Parameters
 DEFAULT_MCMC_N_DIM = 1
-DEFAULT_MCMC_N_WALKERS = 14
-DEFAULT_MCMC_N_STEPS = 1000
-DEFAULT_MCMC_BURNIN = 200
-DEFAULT_MCMC_THIN_BY = 10
+DEFAULT_MCMC_N_WALKERS = CONFIG.mcmc["walkers"]
+DEFAULT_MCMC_N_STEPS = CONFIG.mcmc["steps"]
+DEFAULT_MCMC_BURNIN = CONFIG.mcmc["burnin"]
+DEFAULT_MCMC_THIN_BY = CONFIG.mcmc["thin_by"]
 DEFAULT_MCMC_INITIAL_H0_MEAN = 70.0
 DEFAULT_MCMC_INITIAL_H0_STD = 10.0
-DEFAULT_H0_PRIOR_MIN = 10.0 # km/s/Mpc
-DEFAULT_H0_PRIOR_MAX = 200.0 # km/s/Mpc
+DEFAULT_H0_PRIOR_MIN = CONFIG.mcmc["prior_h0_min"]  # km/s/Mpc
+DEFAULT_H0_PRIOR_MAX = CONFIG.mcmc["prior_h0_max"]  # km/s/Mpc
 
 class H0LogLikelihood:
     def __init__(self, dL_gw_samples, host_galaxies_z, 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from astropy.cosmology import FlatLambdaCDM
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 import emcee
+from gwsiren import CONFIG
 
 # -------------------------------------------------------------------
 # 0.  Fetch posterior samples with pesummary
@@ -37,7 +38,7 @@ dec_samples= np.rad2deg(samples["dec"])
 # -------------------------------------------------------------------
 # 1.  Download (if needed) and load GLADE v2.4
 # -------------------------------------------------------------------
-GLADE_URL = "https://glade.elte.hu/GLADE-2.4.txt"
+GLADE_URL = CONFIG.catalog["glade24_url"]
 GLADE_FILE = "GLADE_2.4.txt"
 
 if not os.path.exists(GLADE_FILE):

--- a/new.py
+++ b/new.py
@@ -12,6 +12,7 @@ Outputs:
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
+from gwsiren import CONFIG
 
 # Import from our new module
 from gw_data_fetcher import fetch_candidate_data, configure_astropy_cache, DEFAULT_CACHE_DIR_NAME
@@ -31,7 +32,7 @@ from sky_analyzer import (
     generate_sky_map_and_credible_region,
     select_galaxies_in_sky_region,
     filter_galaxies_by_redshift,
-    DEFAULT_NSIDE_SKYMAP, 
+    DEFAULT_NSIDE_SKYMAP,
     DEFAULT_PROB_THRESHOLD_CDF
 )
 
@@ -54,7 +55,7 @@ DEFAULT_EVENT_NAME = "GW170817"
 # DEFAULT_SAMPLES_PATH_PREFIX removed as gw_data_fetcher handles table selection
 
 # GLADE Catalog specific
-GLADE_URL = "https://glade.elte.hu/GLADE-2.4.txt"
+GLADE_URL = CONFIG.catalog["glade24_url"]
 GLADE_FILE = "GLADE_2.4.txt"
 GLADE_USE_COLS = [0, 6, 7, 15]  # PGC, RA, Dec, z
 GLADE_COL_NAMES = ['PGC', 'ra', 'dec', 'z']
@@ -66,21 +67,21 @@ GLADE_RANGE_CHECKS = {
 }
 
 # Analysis specific
-NSIDE_SKYMAP = 128
-PROB_THRESHOLD_CDF = 0.95
+NSIDE_SKYMAP = CONFIG.skymap["default_nside"]
+PROB_THRESHOLD_CDF = CONFIG.skymap["credible_level"]
 HOST_Z_MAX = 0.15 # Final redshift cut for candidate hosts
 
 # Cosmological parameters for likelihood
-SIGMA_V_PEC = 250.0  # km/s, peculiar velocity uncertainty
-C_LIGHT = 299792.458 # km/s
-OMEGA_M = 0.31
+SIGMA_V_PEC = CONFIG.cosmology["sigma_v_pec"]  # km/s, peculiar velocity uncertainty
+C_LIGHT = CONFIG.cosmology["c_light"]
+OMEGA_M = CONFIG.cosmology["omega_m"]
 
 # MCMC parameters
 MCMC_N_DIM = 1
-MCMC_N_WALKERS = 32
-MCMC_N_STEPS = 6000
-MCMC_BURNIN = 1000
-MCMC_THIN_BY = 10
+MCMC_N_WALKERS = CONFIG.mcmc["walkers"]
+MCMC_N_STEPS = CONFIG.mcmc["steps"]
+MCMC_BURNIN = CONFIG.mcmc["burnin"]
+MCMC_THIN_BY = CONFIG.mcmc["thin_by"]
 MCMC_INITIAL_H0_MEAN = 70
 MCMC_INITIAL_H0_STD = 10
 

--- a/sky_analyzer.py
+++ b/sky_analyzer.py
@@ -5,12 +5,13 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.cosmology import FlatLambdaCDM, z_at_value
 import logging
+from gwsiren import CONFIG
 
 logger = logging.getLogger(__name__)
 
 # Default Sky Analysis Parameters (can be overridden by passing as arguments to functions)
-DEFAULT_NSIDE_SKYMAP = 128
-DEFAULT_PROB_THRESHOLD_CDF = 0.90 # For 90% credible region
+DEFAULT_NSIDE_SKYMAP = CONFIG.skymap["default_nside"]
+DEFAULT_PROB_THRESHOLD_CDF = CONFIG.skymap["credible_level"]  # For 90% credible region
 # HOST_Z_MAX is intentionally not a global default here, as it's a crucial analysis choice
 # and should be explicitly passed to functions that use it.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,35 @@
+import textwrap
+from gwsiren.config import load_config
+
+
+def test_load_config(tmp_path):
+    cfg_text = textwrap.dedent(
+        """
+        catalog:
+          glade_plus_url:  http://a
+          glade24_url:     http://b
+          data_dir:        d/
+        skymap:
+          default_nside:   16
+          credible_level:  0.85
+        mcmc:
+          walkers:         4
+          steps:           50
+          burnin:          5
+          thin_by:         1
+          prior_h0_min:    1.0
+          prior_h0_max:    2.0
+        cosmology:
+          sigma_v_pec:     100.0
+          c_light:         1.0
+          omega_m:         0.3
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_text)
+
+    cfg = load_config(path)
+    assert cfg.catalog["glade_plus_url"] == "http://a"
+    assert cfg.skymap["default_nside"] == 16
+    assert cfg.mcmc["steps"] == 50
+    assert cfg.cosmology["omega_m"] == 0.3

--- a/viz.py
+++ b/viz.py
@@ -22,6 +22,7 @@ import emcee # For MCMC
 from emcee.interruptible_pool import InterruptiblePool # For parallel MCMC
 import logging # Added logging
 import argparse # Added argparse
+from gwsiren import CONFIG
 
 # Get a logger for this module (configuration will be done in main)
 logger = logging.getLogger(__name__)
@@ -54,9 +55,7 @@ from sky_analyzer import (
     generate_sky_map_and_credible_region,
     select_galaxies_in_sky_region,
     filter_galaxies_by_redshift,
-    estimate_event_specific_z_max,
-    DEFAULT_NSIDE_SKYMAP as MODULE_DEFAULT_NSIDE_SKYMAP, # Avoid name clash if viz.py has its own NSIDE_SKYMAP
-    DEFAULT_PROB_THRESHOLD_CDF as MODULE_DEFAULT_PROB_THRESHOLD_CDF
+    estimate_event_specific_z_max
 )
 
 # H0 MCMC Analysis
@@ -80,10 +79,10 @@ DEFAULT_EVENT_NAME_VIZ = "GW170818"
 VIZ_CATALOG_TYPE = 'glade+' # Specify catalog type: 'glade+' or 'glade24'
 
 # HEALPix Sky Map parameters for this script
-VIZ_NSIDE_SKYMAP = MODULE_DEFAULT_NSIDE_SKYMAP # Use default from sky_analyzer, can be overridden
+VIZ_NSIDE_SKYMAP = CONFIG.skymap["default_nside"]
 
 # Analysis specific for host selection for this script
-VIZ_PROB_THRESHOLD_CDF = MODULE_DEFAULT_PROB_THRESHOLD_CDF # Use default from sky_analyzer
+VIZ_PROB_THRESHOLD_CDF = CONFIG.skymap["credible_level"]
 VIZ_HOST_Z_MAX_FALLBACK = 0.05 
 
 # Galaxy corrections for this script


### PR DESCRIPTION
## Summary
- create repo-wide `config.yaml`
- implement `gwsiren` package with lightweight loader
- reference new configuration values in analysis modules
- provide a small unit test

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*