### PR TITLE
Add config and data fetcher unit tests

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,90 @@
+import textwrap
+import pathlib
+import pytest
+
+from gwsiren.config import load_config, _minimal_yaml_load
+
+
+def test_load_config_from_path(tmp_path):
+    cfg_text = textwrap.dedent(
+        """
+        catalog:
+          glade_plus_url: http://a
+          glade24_url:    http://b
+          data_dir:       d/
+        skymap:
+          default_nside:  16
+          credible_level: 0.85
+        mcmc:
+          walkers:        4
+          steps:          50
+          burnin:         5
+          thin_by:        1
+          prior_h0_min:   1.0
+          prior_h0_max:   2.0
+        cosmology:
+          sigma_v_pec:    100.0
+          c_light:        1.0
+          omega_m:        0.3
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_text)
+
+    cfg = load_config(path)
+    assert cfg.catalog["glade_plus_url"] == "http://a"
+    assert cfg.skymap["default_nside"] == 16
+    assert cfg.mcmc["steps"] == 50
+    assert cfg.cosmology["omega_m"] == 0.3
+
+
+def test_load_config_missing_file(tmp_path):
+    missing = tmp_path / "does_not_exist.yaml"
+    with pytest.raises(RuntimeError):
+        load_config(missing)
+
+
+def test_load_config_default_path(mocker, project_root_dir):
+    cfg_text = textwrap.dedent(
+        """
+        catalog:
+          glade_plus_url: http://x
+          glade24_url:    http://y
+          data_dir:       d/
+        skymap:
+          default_nside:  8
+          credible_level: 0.5
+        mcmc:
+          walkers:        2
+          steps:          10
+          burnin:         1
+          thin_by:        1
+          prior_h0_min:   1.0
+          prior_h0_max:   2.0
+        cosmology:
+          sigma_v_pec:    100.0
+          c_light:        1.0
+          omega_m:        0.3
+        """
+    )
+
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch("pathlib.Path.read_text", return_value=cfg_text)
+
+    cfg = load_config()
+    assert cfg.catalog["glade_plus_url"] == "http://x"
+    assert cfg.skymap["default_nside"] == 8
+    assert cfg.mcmc["steps"] == 10
+    assert cfg.cosmology["omega_m"] == 0.3
+
+
+def test_minimal_yaml_loader_valid_input():
+    text = "root:\n  a: 1\nother:\n  b: 2"
+    data = _minimal_yaml_load(text)
+    assert data == {"root": {"a": 1}, "other": {"b": 2}}
+
+
+def test_minimal_yaml_loader_malformed_indentation():
+    malformed = "  bad: 1\nroot:\n  a: 2"
+    with pytest.raises(ValueError):
+        _minimal_yaml_load(malformed)

--- a/tests/unit/test_gw_data_fetcher.py
+++ b/tests/unit/test_gw_data_fetcher.py
@@ -1,0 +1,97 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from gw_data_fetcher import (
+    configure_astropy_cache,
+    fetch_candidate_data,
+    DEFAULT_CACHE_DIR_NAME,
+)
+
+
+def test_configure_astropy_cache_creates_dir(temp_data_dir):
+    path = configure_astropy_cache(cache_dir_base=temp_data_dir)
+    assert os.path.exists(temp_data_dir)
+    assert path == os.path.abspath(temp_data_dir)
+
+
+def test_configure_astropy_cache_sets_astropy_config(mocker, temp_data_dir):
+    mock_conf = MagicMock()
+    mock_conf.allow_remote_data = False
+    mock_conf.remote_data_strict = True
+    mocker.patch('gw_data_fetcher.astropy_conf', mock_conf)
+
+    path = configure_astropy_cache(cache_dir_base=temp_data_dir)
+    assert mock_conf.cache_dir == os.path.abspath(temp_data_dir)
+    assert mock_conf.allow_remote_data is True
+
+
+def test_fetch_candidate_data_successful_fetch(mocker, mock_config):
+    mock_result = MagicMock()
+    mock_result.samples_dict = {"key": "value"}
+    fetch_mock = mocker.patch('gw_data_fetcher.fetch_open_samples', return_value=mock_result)
+
+    success, result = fetch_candidate_data('GW_TEST_SUCCESS', mock_config.catalog['data_dir'])
+
+    fetch_mock.assert_called_once_with(
+        'GW_TEST_SUCCESS',
+        outdir=mock_config.catalog['data_dir'],
+        download_kwargs={'cache': True}
+    )
+    assert success is True
+    assert result is mock_result
+
+
+def test_fetch_candidate_data_handles_multiple_tables(mocker, mock_config):
+    retry_result = MagicMock()
+    retry_result.samples_dict = {'a': 1}
+
+    def side_effect(*args, **kwargs):
+        if side_effect.call_count == 0:
+            side_effect.call_count += 1
+            raise Exception(
+                'Found multiple posterior sample tables in file: table1.dat, table2.dat. Not sure which to load.'
+            )
+        return retry_result
+
+    side_effect.call_count = 0
+    fetch_mock = mocker.patch('gw_data_fetcher.fetch_open_samples', side_effect=side_effect)
+
+    success, result = fetch_candidate_data('GW_TEST_MULTITABLE', mock_config.catalog['data_dir'])
+
+    assert fetch_mock.call_count == 2
+    assert fetch_mock.call_args_list[1].kwargs.get('path_to_samples') == 'table1.dat'
+    assert success is True
+    assert result is retry_result
+
+
+def test_fetch_candidate_data_handles_unknown_url(mocker, mock_config):
+    fetch_mock = mocker.patch('gw_data_fetcher.fetch_open_samples', side_effect=Exception('Unknown URL problem'))
+
+    success, msg = fetch_candidate_data('GW_TEST_BADURL', mock_config.catalog['data_dir'])
+
+    fetch_mock.assert_called_once()
+    assert success is False
+    assert msg == 'Unknown URL for GW_TEST_BADURL.'
+
+
+def test_fetch_candidate_data_handles_other_exception(mocker, mock_config):
+    fetch_mock = mocker.patch('gw_data_fetcher.fetch_open_samples', side_effect=RuntimeError('Some other PESummary error'))
+
+    success, msg = fetch_candidate_data('GW_TEST_OTHER_ERROR', mock_config.catalog['data_dir'])
+
+    fetch_mock.assert_called_once()
+    assert success is False
+    assert msg == 'Unexpected error for GW_TEST_OTHER_ERROR: Some other PESummary error'
+
+
+def test_fetch_candidate_data_empty_samples_dict(mocker, mock_config):
+    mock_result = MagicMock()
+    mock_result.samples_dict = {}
+    mocker.patch('gw_data_fetcher.fetch_open_samples', return_value=mock_result)
+
+    success, msg = fetch_candidate_data('GW_TEST_EMPTY_SAMPLES', mock_config.catalog['data_dir'])
+
+    assert success is False
+    assert msg.startswith('Fetched GW_TEST_EMPTY_SAMPLES')


### PR DESCRIPTION
## Summary
- add new config loader tests under `tests/unit`
- add tests for gw_data_fetcher including cache config and error handling

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*