### PR TITLE
CI: Add GitHub Actions workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Python CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install ./gw-siren-pipeline
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import importlib.util
+import types
+
+# Path to the internal tests directory
+internal_tests_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'gw-siren-pipeline', 'tests'))
+internal_conftest_path = os.path.join(internal_tests_dir, 'conftest.py')
+
+# Provide a stub for analyze_candidates to avoid import errors in internal conftest
+sys.modules.setdefault('analyze_candidates', types.ModuleType('analyze_candidates'))
+
+# Load the package's conftest so fixtures are shared
+spec = importlib.util.spec_from_file_location('internal_conftest', internal_conftest_path)
+internal_conftest = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(internal_conftest)
+for name in dir(internal_conftest):
+    if not name.startswith('_'):
+        globals()[name] = getattr(internal_conftest, name)
+
+# Make the h0_e2e_pipeline script importable as a module
+scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'gw-siren-pipeline', 'scripts'))
+pipeline_path = os.path.join(scripts_dir, 'h0_e2e_pipeline.py')
+if os.path.exists(pipeline_path):
+    spec = importlib.util.spec_from_file_location('h0_e2e_pipeline', pipeline_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules['h0_e2e_pipeline'] = module


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- expose package fixtures for tests and ensure scripts can be imported

## Testing
- `pytest -q`