### PR TITLE
CI: Add GitHub Actions workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Python CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install ./gw-siren-pipeline
+          pip install pytest
+      - name: Run tests
+        env:
+          GWSIREN_CONFIG: ${{ github.workspace }}/gw-siren-pipeline/config.yaml
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pesummary_cache/
 *.json
 *.jsonl
 *.gif
+*.egg-info/

--- a/gw-siren-pipeline/gwsiren/config.py
+++ b/gw-siren-pipeline/gwsiren/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+import os
 import pathlib
 
 # Try to import PyYAML, fall back to a very small parser if unavailable
@@ -54,11 +55,15 @@ def load_config(path: str | pathlib.Path | None = None) -> Config:
     Args:
         path: Path to config file. If None, looks for config.yaml in root directory.
     """
-    if path is None:
-        # Look for config.yaml in root directory (parent of gwsiren package)
-        cfg_path = pathlib.Path(__file__).parent.parent / 'config.yaml'
-    else:
+    if path is not None:
         cfg_path = pathlib.Path(path)
+    else:
+        env_var = os.getenv("GWSIREN_CONFIG")
+        if env_var:
+            cfg_path = pathlib.Path(env_var)
+        else:
+            # Look for config.yaml in root directory (parent of gwsiren package)
+            cfg_path = pathlib.Path(__file__).parent.parent / 'config.yaml'
         
     if not cfg_path.exists():
         raise RuntimeError(f'Config file not found: {cfg_path}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import importlib.util
+import types
+
+# Ensure the configuration file can be found when gwsiren is installed
+os.environ.setdefault(
+    "GWSIREN_CONFIG",
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "gw-siren-pipeline", "config.yaml")
+    ),
+)
+
+# Path to the internal tests directory
+internal_tests_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'gw-siren-pipeline', 'tests'))
+internal_conftest_path = os.path.join(internal_tests_dir, 'conftest.py')
+
+# Provide a stub for analyze_candidates to avoid import errors in internal conftest
+sys.modules.setdefault('analyze_candidates', types.ModuleType('analyze_candidates'))
+
+# Load the package's conftest so fixtures are shared
+spec = importlib.util.spec_from_file_location('internal_conftest', internal_conftest_path)
+internal_conftest = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(internal_conftest)
+for name in dir(internal_conftest):
+    if not name.startswith('_'):
+        globals()[name] = getattr(internal_conftest, name)
+
+# Make the h0_e2e_pipeline script importable as a module
+scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'gw-siren-pipeline', 'scripts'))
+pipeline_path = os.path.join(scripts_dir, 'h0_e2e_pipeline.py')
+if os.path.exists(pipeline_path):
+    spec = importlib.util.spec_from_file_location('h0_e2e_pipeline', pipeline_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules['h0_e2e_pipeline'] = module


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- ensure package finds configuration at install time
- share fixtures across tests and set default config path

## Testing
- `pytest -q`
