### PR TITLE
Specify dtypes when loading catalogs

### DIFF
--- a/gw-siren-pipeline/gwsiren/data/catalogs.py
+++ b/gw-siren-pipeline/gwsiren/data/catalogs.py
@@ -18,6 +18,13 @@ CATALOG_CONFIGS = {
         # PGC(col 2), RA(col 9), Dec(col 10), z_helio(col 28), placeholder mass proxy column
         'use_cols': [1, 8, 9, 27, 35],
         'col_names': ['PGC', 'ra', 'dec', 'z', 'mass_proxy'],
+        'dtypes': {
+            'PGC': 'int32',
+            'ra': 'float32',
+            'dec': 'float32',
+            'z': 'float32',
+            'mass_proxy': 'float32',
+        },
         'na_vals': ['-99.0', '-999.0', '-9999.0', 'NaN', 'NAN', 'nan', 'NULL', 'null', '', 'N/A', 'n/a', 'None', '...', 'no_value'],
         'display_name': "GLADE+"
     },
@@ -27,6 +34,13 @@ CATALOG_CONFIGS = {
         # PGC, RA, Dec, z, placeholder mass proxy column
         'use_cols': [0, 6, 7, 15, 35],
         'col_names': ['PGC', 'ra', 'dec', 'z', 'mass_proxy'],
+        'dtypes': {
+            'PGC': 'int32',
+            'ra': 'float32',
+            'dec': 'float32',
+            'z': 'float32',
+            'mass_proxy': 'float32',
+        },
         'na_vals': ['-99.0', '-999.0', '-9999.0', 'NaN', 'NAN', 'nan', 'NULL', 'null', '', 'N/A', 'n/a', 'None', '...', 'no_value'],
         'display_name': "GLADE 2.4"
     }
@@ -61,6 +75,10 @@ def download_and_load_galaxy_catalog(catalog_type='glade+'):
 
     Returns:
         pd.DataFrame: Loaded galaxy catalog, or an empty DataFrame on failure.
+
+    Notes:
+        Explicit dtypes are used when reading to minimize parsing overhead and
+        memory usage for large catalogs like GLADE+.
     """
     config = CATALOG_CONFIGS.get(catalog_type.lower())
 
@@ -72,6 +90,7 @@ def download_and_load_galaxy_catalog(catalog_type='glade+'):
     base_filename = config['filename'] # Renamed from filename to base_filename
     use_cols = config['use_cols']
     col_names = config['col_names']
+    dtypes = config.get('dtypes')
     na_vals = config['na_vals']
     catalog_name_print = config['display_name']
 
@@ -95,6 +114,7 @@ def download_and_load_galaxy_catalog(catalog_type='glade+'):
             sep=r"\s+",
             usecols=use_cols,
             names=col_names,
+            dtype=dtypes,
             comment='#',
             low_memory=False,
             na_values=na_vals,

--- a/gw-siren-pipeline/tests/test_galaxy_catalog_handler.py
+++ b/gw-siren-pipeline/tests/test_galaxy_catalog_handler.py
@@ -84,6 +84,16 @@ def test_load_glade_plus_from_local_mock_file(mock_config, caplog, monkeypatch):
         # mass_proxy may be NaN for some rows, so just check dtype
         assert 'mass_proxy' in df.columns, "mass_proxy column should exist"
         assert pd.api.types.is_numeric_dtype(df['mass_proxy']), "mass_proxy should be numeric"
+        # verify expected dtypes were applied when reading
+        expected_dtype = {
+            'PGC': 'int32',
+            'ra': 'float32',
+            'dec': 'float32',
+            'z': 'float32',
+            'mass_proxy': 'float32',
+        }
+        for col, dtype in expected_dtype.items():
+            assert df[col].dtype == dtype
         log_step("All assertions passed")
         
     except Exception as e:


### PR DESCRIPTION
## Summary
- reduce memory usage when loading galaxy catalogs by specifying dtypes
- apply int32 dtype for PGC column
- verify columns are loaded with configured dtypes in tests

## Testing
- `pytest -q`