### PR TITLE
Implement CombinedLogLikelihood module and tests

### DIFF
--- a/gw-siren-pipeline/gwsiren/combined_likelihood.py
+++ b/gw-siren-pipeline/gwsiren/combined_likelihood.py
@@ -1,0 +1,88 @@
+import logging
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+from gwsiren import CONFIG
+from gwsiren.h0_mcmc_analyzer import get_log_likelihood_h0, H0LogLikelihood
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EventDataPackage:
+    """Container holding data for a single gravitational-wave event."""
+
+    event_id: str
+    dl_samples: np.ndarray
+    candidate_galaxies_df: pd.DataFrame
+
+
+class CombinedLogLikelihood:
+    """Combined log-likelihood for multi-event dark siren analysis."""
+
+    def __init__(
+        self,
+        event_data_packages: List[EventDataPackage],
+        global_h0_min: float = CONFIG.mcmc["prior_h0_min"],
+        global_h0_max: float = CONFIG.mcmc["prior_h0_max"],
+        global_alpha_min: float = CONFIG.mcmc.get("prior_alpha_min", -1.0),
+        global_alpha_max: float = CONFIG.mcmc.get("prior_alpha_max", 1.0),
+        sigma_v: float = CONFIG.cosmology["sigma_v_pec"],
+        c_val: float = CONFIG.cosmology["c_light"],
+        omega_m_val: float = CONFIG.cosmology["omega_m"],
+    ) -> None:
+        """Initialize the combined likelihood."""
+        self.event_data_packages = event_data_packages
+        self.global_h0_min = global_h0_min
+        self.global_h0_max = global_h0_max
+        self.global_alpha_min = global_alpha_min
+        self.global_alpha_max = global_alpha_max
+
+        self.single_event_likelihoods: List[H0LogLikelihood] = []
+        for pkg in self.event_data_packages:
+            df = pkg.candidate_galaxies_df
+            likelihood = get_log_likelihood_h0(
+                dL_gw_samples=pkg.dl_samples,
+                host_galaxies_z=df["z"].values,
+                host_galaxies_mass_proxy=df["mass_proxy"].values,
+                host_galaxies_z_err=df["z_err"].values,
+                sigma_v=sigma_v,
+                c_val=c_val,
+                omega_m_val=omega_m_val,
+                h0_min=global_h0_min,
+                h0_max=global_h0_max,
+                alpha_min=global_alpha_min,
+                alpha_max=global_alpha_max,
+            )
+            self.single_event_likelihoods.append(likelihood)
+
+    def __call__(self, theta: List[float]) -> float:
+        """Evaluate the combined log-likelihood for ``theta``.
+
+        Args:
+            theta: Parameter vector ``[H0, alpha]``.
+
+        Returns:
+            The sum of log-likelihoods over all events, or ``-np.inf`` if the
+            parameters fall outside the global priors or any event likelihood
+            evaluates to ``-np.inf``.
+        """
+        H0 = theta[0]
+        alpha = theta[1]
+
+        if not (self.global_h0_min <= H0 <= self.global_h0_max):
+            return -np.inf
+        if not (self.global_alpha_min <= alpha <= self.global_alpha_max):
+            return -np.inf
+
+        total_log_likelihood = 0.0
+        for ll in self.single_event_likelihoods:
+            log_l = ll([H0, alpha])
+            if log_l == -np.inf:
+                return -np.inf
+            total_log_likelihood += log_l
+        return total_log_likelihood
+

--- a/gw-siren-pipeline/tests/unit/test_combined_likelihood.py
+++ b/gw-siren-pipeline/tests/unit/test_combined_likelihood.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pandas as pd
+
+from gwsiren.h0_mcmc_analyzer import H0LogLikelihood
+from gwsiren.combined_likelihood import CombinedLogLikelihood, EventDataPackage
+
+
+def make_event(event_id: str, dl_values: np.ndarray, galaxy_params: dict) -> EventDataPackage:
+    df = pd.DataFrame(galaxy_params)
+    return EventDataPackage(event_id=event_id, dl_samples=dl_values, candidate_galaxies_df=df)
+
+
+def test_prior_handling(mock_config):
+    event = make_event(
+        "E1",
+        np.array([100.0]),
+        {"z": [0.01], "mass_proxy": [1.0], "z_err": [0.0]},
+    )
+    cll = CombinedLogLikelihood([event], global_h0_min=50, global_h0_max=120, global_alpha_min=-1, global_alpha_max=1)
+
+    assert cll([40.0, 0.0]) == -np.inf
+    assert cll([130.0, 0.0]) == -np.inf
+    assert cll([60.0, -2.0]) == -np.inf
+    assert cll([60.0, 2.0]) == -np.inf
+
+
+def test_single_event_matches_individual(mock_config):
+    event = make_event(
+        "E1",
+        np.array([100.0, 110.0]),
+        {"z": [0.01, 0.02], "mass_proxy": [1.0, 2.0], "z_err": [0.0, 0.0]},
+    )
+
+    cll = CombinedLogLikelihood([event])
+    individual_ll = H0LogLikelihood(
+        event.dl_samples,
+        event.candidate_galaxies_df["z"].values,
+        event.candidate_galaxies_df["mass_proxy"].values,
+        event.candidate_galaxies_df["z_err"].values,
+    )
+    theta = [70.0, 0.0]
+
+    assert np.isclose(cll(theta), individual_ll(theta))
+
+
+def test_sum_of_multiple_events(mock_config):
+    event1 = make_event(
+        "E1",
+        np.array([100.0]),
+        {"z": [0.01], "mass_proxy": [1.0], "z_err": [0.0]},
+    )
+    event2 = make_event(
+        "E2",
+        np.array([120.0]),
+        {"z": [0.015], "mass_proxy": [2.0], "z_err": [0.0]},
+    )
+    cll = CombinedLogLikelihood([event1, event2])
+
+    ll1 = H0LogLikelihood(
+        event1.dl_samples,
+        event1.candidate_galaxies_df["z"].values,
+        event1.candidate_galaxies_df["mass_proxy"].values,
+        event1.candidate_galaxies_df["z_err"].values,
+    )
+    ll2 = H0LogLikelihood(
+        event2.dl_samples,
+        event2.candidate_galaxies_df["z"].values,
+        event2.candidate_galaxies_df["mass_proxy"].values,
+        event2.candidate_galaxies_df["z_err"].values,
+    )
+    theta = [70.0, 0.0]
+    expected = ll1(theta) + ll2(theta)
+    assert np.isclose(cll(theta), expected)
+
+
+def test_event_returning_neg_inf_propagates(mock_config):
+    event1 = make_event(
+        "E1",
+        np.array([100.0]),
+        {"z": [0.01], "mass_proxy": [1.0], "z_err": [0.0]},
+    )
+    # negative mass_proxy will trigger -inf when alpha=1
+    event2 = make_event(
+        "E2",
+        np.array([100.0]),
+        {"z": [0.01], "mass_proxy": [-1.0], "z_err": [0.0]},
+    )
+    cll = CombinedLogLikelihood([event1, event2])
+
+    assert cll([70.0, 1.0]) == -np.inf
+


### PR DESCRIPTION
## Summary
- add `CombinedLogLikelihood` class for summing event likelihoods
- include a simple `EventDataPackage` dataclass
- unit tests validating global priors and log-likelihood summation

## Testing
- `pytest -q`