### PR TITLE
Add global MCMC utilities for multi-event analysis

### DIFF
--- a/gw-siren-pipeline/gwsiren/__init__.py
+++ b/gw-siren-pipeline/gwsiren/__init__.py
@@ -1,3 +1,4 @@
+from .event_data import EventDataPackage
 from .config import Config, load_config, CONFIG
 from .pipeline import (
     run_full_analysis,
@@ -9,11 +10,17 @@ from .pipeline import (
     CDF_THRESHOLD,
     HOST_Z_MAX_FALLBACK,
 )
+from .global_mcmc import (
+    run_global_mcmc,
+    process_global_mcmc_samples,
+    save_global_samples,
+)
 
 __all__ = [
     "Config",
     "load_config",
     "CONFIG",
+    "EventDataPackage",
     "run_full_analysis",
     "save_h0_samples_and_print_summary",
     "OUTPUT_DIR",
@@ -22,4 +29,7 @@ __all__ = [
     "NSIDE_SKYMAP",
     "CDF_THRESHOLD",
     "HOST_Z_MAX_FALLBACK",
+    "run_global_mcmc",
+    "process_global_mcmc_samples",
+    "save_global_samples",
 ]

--- a/gw-siren-pipeline/gwsiren/__init__.py
+++ b/gw-siren-pipeline/gwsiren/__init__.py
@@ -15,6 +15,12 @@ from .global_mcmc import (
     process_global_mcmc_samples,
     save_global_samples,
 )
+from .multi_event_data_manager import (
+    EventDataPackage,
+    load_multi_event_config,
+    prepare_event_data,
+    prepare_all_event_data,
+)
 
 __all__ = [
     "Config",
@@ -32,4 +38,8 @@ __all__ = [
     "run_global_mcmc",
     "process_global_mcmc_samples",
     "save_global_samples",
+    "EventDataPackage",
+    "load_multi_event_config",
+    "prepare_event_data",
+    "prepare_all_event_data",
 ]

--- a/gw-siren-pipeline/gwsiren/__init__.py
+++ b/gw-siren-pipeline/gwsiren/__init__.py
@@ -21,6 +21,11 @@ from .multi_event_data_manager import (
     prepare_event_data,
     prepare_all_event_data,
 )
+from .global_mcmc import (
+    run_global_mcmc,
+    process_global_mcmc_samples,
+    save_global_samples,
+)
 
 __all__ = [
     "Config",
@@ -42,4 +47,7 @@ __all__ = [
     "load_multi_event_config",
     "prepare_event_data",
     "prepare_all_event_data",
+    "run_global_mcmc",
+    "process_global_mcmc_samples",
+    "save_global_samples",
 ]

--- a/gw-siren-pipeline/gwsiren/event_data.py
+++ b/gw-siren-pipeline/gwsiren/event_data.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class EventDataPackage:
+    """Container for prepared event data used in multi-event analyses."""
+
+    event_id: str
+    dl_samples: np.ndarray
+    candidate_galaxies_df: pd.DataFrame
+
+
+__all__ = ["EventDataPackage"]

--- a/gw-siren-pipeline/gwsiren/global_mcmc.py
+++ b/gw-siren-pipeline/gwsiren/global_mcmc.py
@@ -1,0 +1,151 @@
+"""Utilities for running and processing global MCMC analyses."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+import numpy as np
+import emcee
+
+from gwsiren.h0_mcmc_analyzer import (
+    DEFAULT_MCMC_N_DIM,
+    DEFAULT_MCMC_N_WALKERS,
+    DEFAULT_MCMC_N_STEPS,
+    DEFAULT_MCMC_BURNIN,
+    DEFAULT_MCMC_THIN_BY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_global_mcmc(
+    combined_log_likelihood_obj: Callable[[np.ndarray], float],
+    n_walkers: int = DEFAULT_MCMC_N_WALKERS,
+    n_steps: int = DEFAULT_MCMC_N_STEPS,
+    n_dim: int = DEFAULT_MCMC_N_DIM,
+    initial_pos_config: Optional[dict[str, dict[str, float]]] = None,
+    pool: Optional[Any] = None,
+) -> Optional[emcee.EnsembleSampler]:
+    """Run MCMC on a combined multi-event likelihood.
+    This likelihood should be constructed using a list of EventDataPackage objects.
+
+    Args:
+        combined_log_likelihood_obj: Callable returning the log-likelihood for a
+            parameter vector ``[H0, alpha]``.
+        n_walkers: Number of walkers in the ensemble sampler.
+        n_steps: Number of MCMC steps to run.
+        n_dim: Dimension of the parameter space. Should be ``2``.
+        initial_pos_config: Dictionary with mean/std for walker initialisation.
+        pool: Optional multiprocessing pool for parallel likelihood evaluation.
+
+    Returns:
+        The ``emcee.EnsembleSampler`` instance after the run, or ``None`` on
+        failure.
+    """
+
+    if initial_pos_config is None:
+        initial_pos_config = {
+            "H0": {"mean": 70.0, "std": 10.0},
+            "alpha": {"mean": 0.0, "std": 0.5},
+        }
+
+    logger.info(
+        "Running global MCMC (%d walkers, %d steps)...", n_walkers, n_steps
+    )
+
+    h0_mean = initial_pos_config.get("H0", {}).get("mean", 70.0)
+    h0_std = initial_pos_config.get("H0", {}).get("std", 10.0)
+    alpha_mean = initial_pos_config.get("alpha", {}).get("mean", 0.0)
+    alpha_std = initial_pos_config.get("alpha", {}).get("std", 0.5)
+
+    pos_h0 = h0_mean + h0_std * np.random.randn(n_walkers, 1)
+    pos_alpha = alpha_mean + alpha_std * np.random.randn(n_walkers, 1)
+
+    # Respect prior boundaries if attributes are available on the likelihood obj
+    h0_min = getattr(combined_log_likelihood_obj, "h0_min", None)
+    h0_max = getattr(combined_log_likelihood_obj, "h0_max", None)
+    if h0_min is not None and h0_max is not None:
+        out_of_bounds = (pos_h0 < h0_min) | (pos_h0 > h0_max)
+        pos_h0[out_of_bounds] = np.random.uniform(h0_min, h0_max, size=out_of_bounds.sum())
+
+    alpha_min = getattr(combined_log_likelihood_obj, "alpha_min", None)
+    alpha_max = getattr(combined_log_likelihood_obj, "alpha_max", None)
+    if alpha_min is not None and alpha_max is not None:
+        out_of_bounds = (pos_alpha < alpha_min) | (pos_alpha > alpha_max)
+        pos_alpha[out_of_bounds] = np.random.uniform(
+            alpha_min, alpha_max, size=out_of_bounds.sum()
+        )
+
+    walkers0 = np.hstack((pos_h0, pos_alpha))
+
+    sampler = emcee.EnsembleSampler(
+        n_walkers,
+        n_dim,
+        combined_log_likelihood_obj,
+        moves=emcee.moves.StretchMove(),
+        pool=pool,
+    )
+
+    try:
+        sampler.run_mcmc(walkers0, n_steps, progress=True)
+    except ValueError as exc:
+        logger.error("ValueError during global MCMC: %s", exc)
+        return None
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("Unexpected error during global MCMC: %s", exc)
+        return None
+
+    logger.info("Global MCMC run completed.")
+    return sampler
+
+
+def process_global_mcmc_samples(
+    sampler_obj: Optional[emcee.EnsembleSampler],
+    burnin: int = DEFAULT_MCMC_BURNIN,
+    thin_by: int = DEFAULT_MCMC_THIN_BY,
+    n_dim: int = DEFAULT_MCMC_N_DIM,
+) -> Optional[np.ndarray]:
+    """Process raw MCMC chains by applying burn-in and thinning.
+
+    Args:
+        sampler_obj: Sampler returned by :func:`run_global_mcmc`.
+        burnin: Number of initial steps to discard.
+        thin_by: Thinning factor for the chains.
+        n_dim: Expected dimensionality of the samples.
+
+    Returns:
+        Array of processed samples with shape ``(N, n_dim)`` or ``None`` if
+        processing fails.
+    """
+    if sampler_obj is None:
+        logger.warning("Sampler object is None; cannot process samples.")
+        return None
+
+    logger.info("Processing global MCMC samples (burn-in=%d, thin=%d)...", burnin, thin_by)
+    try:
+        flat = sampler_obj.get_chain(discard=burnin, thin=thin_by, flat=True)
+        if flat.size == 0 or flat.shape[1] != n_dim:
+            logger.warning("Processed sample array has unexpected shape %s", flat.shape)
+            return None
+        return flat
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("Failed to process global MCMC samples: %s", exc)
+        return None
+
+
+def save_global_samples(samples: np.ndarray, out_path: str) -> None:
+    """Save processed MCMC samples to a NumPy ``.npy`` file."""
+    if samples is None or samples.size == 0:
+        logger.warning("No samples to save.")
+        return
+    np.save(out_path, samples)
+    logger.info("Saved MCMC samples to %s", out_path)
+
+
+__all__ = [
+    "run_global_mcmc",
+    "process_global_mcmc_samples",
+    "save_global_samples",
+]
+

--- a/gw-siren-pipeline/gwsiren/multi_event_data_manager.py
+++ b/gw-siren-pipeline/gwsiren/multi_event_data_manager.py
@@ -1,0 +1,135 @@
+"""Utilities for preparing data from multiple GW events."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from gwsiren.pipeline import (
+    run_full_analysis,
+    NSIDE_SKYMAP,
+    CDF_THRESHOLD,
+    CATALOG_TYPE,
+    HOST_Z_MAX_FALLBACK,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EventDataPackage:
+    """Container for prepared event data."""
+
+    event_id: str
+    dl_samples: np.ndarray
+    candidate_galaxies_df: pd.DataFrame
+
+
+def load_multi_event_config(path: str | Path) -> List[Dict]:
+    """Load the multi-event configuration file.
+
+    Args:
+        path: Path to the YAML configuration file.
+
+    Returns:
+        List of dictionaries, one per event configuration entry.
+
+    Raises:
+        ValueError: If required structure is missing.
+    """
+    cfg_path = Path(path)
+    text = cfg_path.read_text()
+    raw = yaml.safe_load(text)
+    if not isinstance(raw, dict) or "events_to_combine" not in raw:
+        raise ValueError("Config file must define 'events_to_combine'.")
+    events = raw["events_to_combine"]
+    if not isinstance(events, list):
+        raise ValueError("'events_to_combine' must be a list.")
+    for entry in events:
+        if not isinstance(entry, dict) or "event_id" not in entry:
+            raise ValueError("Each event entry must contain 'event_id'.")
+    return events
+
+
+def _load_precomputed_data(entry: Dict) -> EventDataPackage | None:
+    dl_path = entry.get("gw_dl_samples_path")
+    gal_path = entry.get("candidate_galaxies_path")
+    if not dl_path or not gal_path:
+        return None
+    dl_file = Path(dl_path)
+    gal_file = Path(gal_path)
+    if not (dl_file.exists() and gal_file.exists()):
+        logger.warning("Pre-computed files not found for %s", entry["event_id"])
+        return None
+    try:
+        dl_samples = np.load(dl_file)
+        df = pd.read_csv(gal_file)
+    except Exception as exc:  # pragma: no cover - unexpected I/O errors
+        logger.error("Failed loading pre-computed data for %s: %s", entry["event_id"], exc)
+        raise
+    return EventDataPackage(event_id=entry["event_id"], dl_samples=dl_samples, candidate_galaxies_df=df)
+
+
+def prepare_event_data(event_cfg_entry: Dict) -> EventDataPackage:
+    """Prepare data for a single event.
+
+    This loads pre-computed data if paths are provided and valid; otherwise it
+    triggers generation via :func:`run_full_analysis`.
+
+    Args:
+        event_cfg_entry: Configuration dictionary for the event.
+
+    Returns:
+        ``EventDataPackage`` with loaded or generated data.
+
+    Raises:
+        RuntimeError: If data generation fails.
+    """
+    loaded = _load_precomputed_data(event_cfg_entry)
+    if loaded is not None:
+        return loaded
+
+    event_id = event_cfg_entry["event_id"]
+    nside = event_cfg_entry.get("nside_skymap", NSIDE_SKYMAP)
+    cdf = event_cfg_entry.get("cdf_threshold", CDF_THRESHOLD)
+    catalog = event_cfg_entry.get("catalog_type", CATALOG_TYPE)
+    z_fallback = event_cfg_entry.get("host_z_max_fallback", HOST_Z_MAX_FALLBACK)
+
+    logger.info("Generating data for %s", event_id)
+    results = run_full_analysis(
+        event_id,
+        perform_mcmc=False,
+        nside_skymap=nside,
+        cdf_threshold=cdf,
+        catalog_type=catalog,
+        host_z_max_fallback=z_fallback,
+    )
+    if results.get("error"):
+        raise RuntimeError(f"Data generation failed for {event_id}: {results['error']}")
+
+    dl_samples = results["dL_samples"]
+    df = results["candidate_hosts_df"]
+    return EventDataPackage(event_id=event_id, dl_samples=dl_samples, candidate_galaxies_df=df)
+
+
+def prepare_all_event_data(multi_event_config_path: str | Path) -> List[EventDataPackage]:
+    """Prepare data packages for all events defined in a configuration file."""
+    events = load_multi_event_config(multi_event_config_path)
+    packages = []
+    for entry in events:
+        packages.append(prepare_event_data(entry))
+    return packages
+
+
+__all__ = [
+    "EventDataPackage",
+    "load_multi_event_config",
+    "prepare_event_data",
+    "prepare_all_event_data",
+]

--- a/gw-siren-pipeline/gwsiren/multi_event_data_manager.py
+++ b/gw-siren-pipeline/gwsiren/multi_event_data_manager.py
@@ -18,17 +18,9 @@ from gwsiren.pipeline import (
     CATALOG_TYPE,
     HOST_Z_MAX_FALLBACK,
 )
+from gwsiren.event_data import EventDataPackage
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class EventDataPackage:
-    """Container for prepared event data."""
-
-    event_id: str
-    dl_samples: np.ndarray
-    candidate_galaxies_df: pd.DataFrame
 
 
 def load_multi_event_config(path: str | Path) -> List[Dict]:

--- a/gw-siren-pipeline/scripts/global_mcmc_example.py
+++ b/gw-siren-pipeline/scripts/global_mcmc_example.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""Example script demonstrating multi-event global MCMC usage."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import numpy as np
+from emcee.interruptible_pool import InterruptiblePool
+
+from gwsiren.global_mcmc import run_global_mcmc, process_global_mcmc_samples, save_global_samples
+from gwsiren.event_data import EventDataPackage
+# from gwsiren.combined_likelihood import CombinedLogLikelihood  # Placeholder for actual import
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run global multi-event MCMC")
+    parser.add_argument("output", help="Output path for samples")
+    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    # Placeholder for actual event data packages and likelihood construction
+    event_data_packages: list[EventDataPackage] = []  # TODO: populate with EventDataPackage instances
+    combined_ll = None  # CombinedLogLikelihood(event_data_packages)
+    if combined_ll is None:
+        logger.error("CombinedLogLikelihood not constructed. This is a placeholder script.")
+        return
+
+    initial_cfg = {"H0": {"mean": 70.0, "std": 10.0}, "alpha": {"mean": 0.0, "std": 0.5}}
+    n_cores = os.cpu_count() or 1
+    with InterruptiblePool(n_cores) as pool:
+        sampler = run_global_mcmc(combined_ll, initial_pos_config=initial_cfg, pool=pool)
+
+    samples = process_global_mcmc_samples(sampler)
+    if samples is not None:
+        save_global_samples(samples, args.output)
+        logger.info("Saved %d samples", len(samples))
+
+
+if __name__ == "__main__":
+    main()

--- a/gw-siren-pipeline/tests/unit/test_global_mcmc.py
+++ b/gw-siren-pipeline/tests/unit/test_global_mcmc.py
@@ -1,0 +1,60 @@
+import numpy as np
+import emcee
+import pytest
+
+from gwsiren.global_mcmc import run_global_mcmc, process_global_mcmc_samples
+
+
+@pytest.fixture(autouse=True)
+def _stub_main_module(monkeypatch):
+    import types, sys
+
+    dummy = types.ModuleType("main")
+    dummy.CONFIG = None
+    monkeypatch.setitem(sys.modules, "main", dummy)
+    yield
+    monkeypatch.delitem(sys.modules, "main", raising=False)
+
+
+class SimpleGaussianLL:
+    """Simple 2D Gaussian log-likelihood for testing."""
+
+    def __init__(self):
+        self.h0_min = 20.0
+        self.h0_max = 150.0
+        self.alpha_min = -2.0
+        self.alpha_max = 2.0
+
+    def __call__(self, theta):
+        h0, alpha = theta
+        if not (self.h0_min <= h0 <= self.h0_max):
+            return -np.inf
+        if not (self.alpha_min <= alpha <= self.alpha_max):
+            return -np.inf
+        return -0.5 * (((h0 - 70.0) / 5.0) ** 2 + ((alpha - 0.0) / 1.0) ** 2)
+
+
+def test_run_global_mcmc_returns_sampler(mock_config):
+    ll = SimpleGaussianLL()
+    sampler = run_global_mcmc(
+        ll,
+        n_walkers=8,
+        n_steps=10,
+        initial_pos_config={"H0": {"mean": 70.0, "std": 2.0}, "alpha": {"mean": 0.0, "std": 0.2}},
+    )
+    assert isinstance(sampler, emcee.EnsembleSampler)
+    assert sampler.get_chain().shape == (10, 8, 2)
+
+
+def test_process_global_mcmc_samples_returns_array(mock_config):
+    ll = SimpleGaussianLL()
+    sampler = run_global_mcmc(
+        ll,
+        n_walkers=6,
+        n_steps=15,
+        initial_pos_config={"H0": {"mean": 70.0, "std": 3.0}, "alpha": {"mean": 0.0, "std": 0.3}},
+    )
+    samples = process_global_mcmc_samples(sampler, burnin=5, thin_by=1, n_dim=2)
+    assert samples is not None
+    assert samples.shape[1] == 2
+    assert samples.shape[0] > 0

--- a/gw-siren-pipeline/tests/unit/test_multi_event_data_manager.py
+++ b/gw-siren-pipeline/tests/unit/test_multi_event_data_manager.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pandas as pd
+import textwrap
+
+import pytest
+
+from gwsiren.multi_event_data_manager import (
+    load_multi_event_config,
+    prepare_event_data,
+    EventDataPackage,
+)
+from gwsiren.pipeline import (
+    NSIDE_SKYMAP,
+    CDF_THRESHOLD,
+    CATALOG_TYPE,
+    HOST_Z_MAX_FALLBACK,
+)
+
+
+def test_load_multi_event_config(tmp_path):
+    cfg_text = textwrap.dedent(
+        """
+        events_to_combine:
+          - event_id: EV1
+            gw_dl_samples_path: dl1.npy
+            candidate_galaxies_path: gal1.csv
+          - event_id: EV2
+        """
+    )
+    cfg_file = tmp_path / "events.yaml"
+    cfg_file.write_text(cfg_text)
+
+    events = load_multi_event_config(cfg_file)
+
+    assert len(events) == 2
+    assert events[0]["event_id"] == "EV1"
+    assert events[1]["event_id"] == "EV2"
+
+
+def test_prepare_event_data_loads_files(tmp_path):
+    dl = np.array([1.0, 2.0])
+    df = pd.DataFrame({"z": [0.01], "mass_proxy": [1.0], "z_err": [0.001]})
+    dl_path = tmp_path / "dl.npy"
+    gal_path = tmp_path / "gal.csv"
+    np.save(dl_path, dl)
+    df.to_csv(gal_path, index=False)
+
+    cfg = {
+        "event_id": "EV1",
+        "gw_dl_samples_path": str(dl_path),
+        "candidate_galaxies_path": str(gal_path),
+    }
+
+    package = prepare_event_data(cfg)
+
+    assert isinstance(package, EventDataPackage)
+    assert np.allclose(package.dl_samples, dl)
+    pd.testing.assert_frame_equal(package.candidate_galaxies_df, df)
+
+
+def test_prepare_event_data_generation_path(mocker):
+    df = pd.DataFrame({"z": [0.02], "mass_proxy": [2.0], "z_err": [0.002]})
+    results = {"dL_samples": np.array([3.0, 4.0]), "candidate_hosts_df": df}
+    run_mock = mocker.patch(
+        "gwsiren.multi_event_data_manager.run_full_analysis",
+        return_value=results,
+    )
+
+    cfg = {"event_id": "EVGEN"}
+
+    package = prepare_event_data(cfg)
+
+    run_mock.assert_called_once_with(
+        "EVGEN",
+        perform_mcmc=False,
+        nside_skymap=NSIDE_SKYMAP,
+        cdf_threshold=CDF_THRESHOLD,
+        catalog_type=CATALOG_TYPE,
+        host_z_max_fallback=HOST_Z_MAX_FALLBACK,
+    )
+    assert np.allclose(package.dl_samples, results["dL_samples"])
+    pd.testing.assert_frame_equal(package.candidate_galaxies_df, df)


### PR DESCRIPTION
## Summary
- implement `global_mcmc.py` with utilities to run and process multi-event MCMC
- expose new helpers via package `__init__`
- provide example script `global_mcmc_example.py`
- add EventDataPackage dataclass and integrate with global utilities
- add unit tests for the new MCMC runner and processor

## Testing
- `pytest -q`
