### PR TITLE
Add multi-event config support

### DIFF
--- a/gw-siren-pipeline/config.yaml
+++ b/gw-siren-pipeline/config.yaml
@@ -26,3 +26,27 @@ fetcher:
   cache_dir_name:  pesummary_cache
   timeout:         30
   max_retries:     3
+
+# Example settings for combining multiple events
+multi_event_analysis:
+  run_settings:
+    run_label: "demo_run"
+    base_output_directory: "output/multi_event_runs/"
+  events_to_combine:
+    - event_id: "GW170817"
+      # gw_dl_samples_path: "precomputed/GW170817/dL_samples.npy"
+      # candidate_galaxies_path: "precomputed/GW170817/hosts.csv"
+    - event_id: "GW190814"
+  priors:
+    H0: { min: 10.0, max: 200.0 }
+    alpha: { min: -2.0, max: 2.0 }
+  mcmc:
+    n_walkers: 100
+    n_steps: 5000
+    burnin: 1000
+    thin_by: 10
+    initial_pos_config:
+      H0: { mean: 70.0, std: 5.0 }
+      alpha: { mean: 0.0, std: 0.2 }
+  cosmology:
+    sigma_v_pec: 300.0

--- a/gw-siren-pipeline/gwsiren/config.py
+++ b/gw-siren-pipeline/gwsiren/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 import pathlib
 import os
 
@@ -42,6 +43,136 @@ def _minimal_yaml_load(text: str) -> dict:
 
 
 @dataclass(frozen=True)
+class MEInitialPosParam:
+    """Initial position configuration for a parameter."""
+
+    mean: float
+    std: float
+
+
+@dataclass(frozen=True)
+class MEMCMCConfig:
+    """MCMC configuration specific to multi-event analysis."""
+
+    n_walkers: Optional[int] = None
+    n_steps: Optional[int] = None
+    burnin: Optional[int] = None
+    thin_by: Optional[int] = None
+    initial_pos_config: Optional[Dict[str, MEInitialPosParam]] = None
+
+
+@dataclass(frozen=True)
+class MECosmologyConfig:
+    """Cosmology configuration overrides for multi-event analysis."""
+
+    sigma_v_pec: Optional[float] = None
+    c_light: Optional[float] = None
+    omega_m_val: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class MEPriorBoundaries:
+    """Prior bounds for a parameter."""
+
+    min: float
+    max: float
+
+
+@dataclass(frozen=True)
+class MEEventToCombine:
+    """Single event entry within the multi-event configuration."""
+
+    event_id: str
+    gw_dl_samples_path: Optional[str] = None
+    candidate_galaxies_path: Optional[str] = None
+    single_event_processing_params: Optional[Dict[str, object]] = None
+
+
+@dataclass(frozen=True)
+class MERunSettings:
+    """General run settings for multi-event analysis."""
+
+    run_label: Optional[str] = None
+    base_output_directory: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MultiEventAnalysisSettings:
+    """Top-level container for multi-event analysis settings."""
+
+    run_settings: Optional[MERunSettings] = None
+    events_to_combine: List[MEEventToCombine] = field(default_factory=list)
+    priors: Optional[Dict[str, MEPriorBoundaries]] = None
+    mcmc: Optional[MEMCMCConfig] = None
+    cosmology: Optional[MECosmologyConfig] = None
+
+
+def _parse_multi_event_config(raw: Dict) -> MultiEventAnalysisSettings:
+    """Convert a raw dictionary into ``MultiEventAnalysisSettings``."""
+
+    run_raw = raw.get("run_settings")
+    run_cfg = MERunSettings(**run_raw) if isinstance(run_raw, dict) else None
+
+    events_cfg: List[MEEventToCombine] = []
+    events_raw = raw.get("events_to_combine", [])
+    if not isinstance(events_raw, list):
+        raise ValueError("'events_to_combine' must be a list")
+    for entry in events_raw:
+        if not isinstance(entry, dict) or "event_id" not in entry:
+            raise ValueError("Each event entry must contain 'event_id'")
+        events_cfg.append(
+            MEEventToCombine(
+                event_id=entry["event_id"],
+                gw_dl_samples_path=entry.get("gw_dl_samples_path"),
+                candidate_galaxies_path=entry.get("candidate_galaxies_path"),
+                single_event_processing_params=entry.get(
+                    "single_event_processing_params"
+                ),
+            )
+        )
+
+    priors_raw = raw.get("priors")
+    priors_cfg = None
+    if isinstance(priors_raw, dict):
+        priors_cfg = {
+            key: MEPriorBoundaries(**val) for key, val in priors_raw.items()
+        }
+
+    mcmc_raw = raw.get("mcmc")
+    mcmc_cfg = None
+    if isinstance(mcmc_raw, dict):
+        init_raw = mcmc_raw.get("initial_pos_config")
+        init_cfg = None
+        if isinstance(init_raw, dict):
+            init_cfg = {
+                k: MEInitialPosParam(**v) for k, v in init_raw.items()
+            }
+        mcmc_cfg = MEMCMCConfig(
+            n_walkers=mcmc_raw.get("n_walkers"),
+            n_steps=mcmc_raw.get("n_steps"),
+            burnin=mcmc_raw.get("burnin"),
+            thin_by=mcmc_raw.get("thin_by"),
+            initial_pos_config=init_cfg,
+        )
+
+    cosmo_raw = raw.get("cosmology")
+    cosmo_cfg = None
+    if isinstance(cosmo_raw, dict):
+        cosmo_cfg = MECosmologyConfig(
+            sigma_v_pec=cosmo_raw.get("sigma_v_pec"),
+            c_light=cosmo_raw.get("c_light"),
+            omega_m_val=cosmo_raw.get("omega_m_val"),
+        )
+
+    return MultiEventAnalysisSettings(
+        run_settings=run_cfg,
+        events_to_combine=events_cfg,
+        priors=priors_cfg,
+        mcmc=mcmc_cfg,
+        cosmology=cosmo_cfg,
+    )
+
+@dataclass(frozen=True)
 class Config:
     """Typed container for configuration sections."""
 
@@ -50,6 +181,7 @@ class Config:
     mcmc: dict
     cosmology: dict
     fetcher: dict
+    multi_event_analysis: Optional[MultiEventAnalysisSettings] = None
 
 
 def load_config(path: str | pathlib.Path | None = None) -> Config:
@@ -76,7 +208,13 @@ def load_config(path: str | pathlib.Path | None = None) -> Config:
         raw = _pyyaml.safe_load(text)
     else:
         raw = _minimal_yaml_load(text)
-    return Config(**raw)
+    me_raw = raw.get("multi_event_analysis")
+    if me_raw is not None:
+        raw.pop("multi_event_analysis")
+        me_cfg = _parse_multi_event_config(me_raw)
+    else:
+        me_cfg = None
+    return Config(**raw, multi_event_analysis=me_cfg)
 
 
 CONFIG = load_config()

--- a/gw-siren-pipeline/tests/unit/test_config_multi_event.py
+++ b/gw-siren-pipeline/tests/unit/test_config_multi_event.py
@@ -1,0 +1,136 @@
+"""Tests for multi-event configuration parsing."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from gwsiren.config import load_config
+
+
+def _base_yaml() -> str:
+    return textwrap.dedent(
+        """
+        catalog:
+          glade_plus_url: http://a
+          glade24_url: http://b
+          data_dir: d/
+        skymap:
+          default_nside: 16
+          credible_level: 0.9
+        mcmc:
+          walkers: 4
+          steps: 50
+          burnin: 5
+          thin_by: 1
+          prior_h0_min: 1.0
+          prior_h0_max: 2.0
+        cosmology:
+          sigma_v_pec: 100.0
+          c_light: 1.0
+          omega_m: 0.3
+        fetcher:
+          cache_dir_name: cache
+          timeout: 5
+          max_retries: 1
+        """
+    )
+
+
+def test_full_multi_event_config(tmp_path):
+    cfg_text = _base_yaml() + textwrap.dedent(
+        """
+        multi_event_analysis:
+          run_settings:
+            run_label: run1
+            base_output_directory: out/
+          events_to_combine:
+            - event_id: EV1
+              gw_dl_samples_path: dl.npy
+              candidate_galaxies_path: gal.csv
+            - event_id: EV2
+          priors:
+            H0: {min: 50.0, max: 100.0}
+            alpha: {min: -1.0, max: 1.0}
+          mcmc:
+            n_walkers: 10
+            n_steps: 20
+            burnin: 2
+            thin_by: 1
+            initial_pos_config:
+              H0: {mean: 70.0, std: 5.0}
+              alpha: {mean: 0.0, std: 0.2}
+          cosmology:
+            sigma_v_pec: 250.0
+            c_light: 299792.458
+            omega_m_val: 0.31
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_text)
+
+    cfg = load_config(path)
+
+    me = cfg.multi_event_analysis
+    assert me is not None
+    assert me.run_settings.run_label == "run1"
+    assert len(me.events_to_combine) == 2
+    assert me.priors["H0"].max == 100.0
+    assert me.mcmc.n_steps == 20
+    assert me.cosmology.omega_m_val == 0.31
+
+
+def test_no_multi_event_section(tmp_path):
+    path = tmp_path / "cfg.yaml"
+    path.write_text(_base_yaml())
+
+    cfg = load_config(path)
+    assert cfg.multi_event_analysis is None
+
+
+def test_minimal_multi_event_section(tmp_path):
+    cfg_text = _base_yaml() + textwrap.dedent(
+        """
+        multi_event_analysis:
+          events_to_combine:
+            - event_id: EV1
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_text)
+
+    cfg = load_config(path)
+
+    assert cfg.multi_event_analysis is not None
+    assert cfg.multi_event_analysis.events_to_combine[0].event_id == "EV1"
+
+
+def test_invalid_event_list(tmp_path):
+    cfg_text = _base_yaml() + textwrap.dedent(
+        """
+        multi_event_analysis:
+          events_to_combine: not_a_list
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_text)
+
+    with pytest.raises(ValueError):
+        load_config(path)
+
+
+def test_invalid_event_entry(tmp_path):
+    cfg_text = _base_yaml() + textwrap.dedent(
+        """
+        multi_event_analysis:
+          events_to_combine:
+            - wrong: field
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_text)
+
+    with pytest.raises(ValueError):
+        load_config(path)
+

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,14 @@ Global settings such as catalogue paths, MCMC parameters, and cosmology assumpti
 
 To override the default config, set the environment variable `GWSIREN_CONFIG` to point to an alternative YAML file.
 
+### Multi-Event Configuration
+
+The optional `multi_event_analysis` section in `config.yaml` collects settings
+for combining multiple gravitational-wave events in a single run. When present,
+it defines which events to process, global priors on `H0` and `alpha`, optional
+MCMC overrides, and cosmology parameters. A minimal example is provided at the
+end of `config.yaml`.
+
 ## Running Tests
 
 Project tests are written with `pytest`. Execute them from the repository root:


### PR DESCRIPTION
## Summary
- extend configuration dataclasses to parse new `multi_event_analysis` section
- provide example multi-event settings in `config.yaml`
- document multi-event config usage in README
- add unit tests covering parsing of multi-event config

## Testing
- `pytest -q`