### PR TITLE
Add GW posteriors caching

### DIFF
--- a/gw-siren-pipeline/README.md
+++ b/gw-siren-pipeline/README.md
@@ -12,3 +12,13 @@ A Python project for gravitational wave data analysis and H0 estimation.
 ## Setup (Placeholder)
 
 To be updated as the project is refactored.
+
+## Caching
+
+The pipeline caches intermediate data to avoid repeated downloads and
+processing. Two key directories can be configured in `config.yaml` under the
+`multi_event_analysis.run_settings` section:
+
+- `candidate_galaxy_cache_dir` – stores per-event candidate galaxy tables.
+- `gw_posteriors_cache_dir` – stores extracted GW posterior samples
+  (`dL`, `ra`, `dec`) in `.npz` files.

--- a/gw-siren-pipeline/config.yaml
+++ b/gw-siren-pipeline/config.yaml
@@ -33,9 +33,9 @@ multi_event_analysis:
     run_label: "demo_run"
     base_output_directory: "output/multi_event_runs/"
     candidate_galaxy_cache_dir: "cache/candidate_galaxies/"
+    gw_posteriors_cache_dir: "cache/gw_posteriors/"
   events_to_combine:
     - event_id: "GW170817"
-      # gw_dl_samples_path: "precomputed/GW170817/dL_samples.npy"
     - event_id: "GW190814"
   priors:
     H0: { min: 10.0, max: 200.0 }

--- a/gw-siren-pipeline/gwsiren/config.py
+++ b/gw-siren-pipeline/gwsiren/config.py
@@ -83,7 +83,6 @@ class MEEventToCombine:
     """Single event entry within the multi-event configuration."""
 
     event_id: str
-    gw_dl_samples_path: Optional[str] = None
     single_event_processing_params: Optional[Dict[str, object]] = None
 
 
@@ -94,6 +93,7 @@ class MERunSettings:
     run_label: Optional[str] = None
     base_output_directory: Optional[str] = None
     candidate_galaxy_cache_dir: Optional[str] = "cache/candidate_galaxies/"
+    gw_posteriors_cache_dir: Optional[str] = "cache/gw_posteriors/"
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,6 @@ def _parse_multi_event_config(raw: Dict) -> MultiEventAnalysisSettings:
         events_cfg.append(
             MEEventToCombine(
                 event_id=entry["event_id"],
-                gw_dl_samples_path=entry.get("gw_dl_samples_path"),
                 single_event_processing_params=entry.get(
                     "single_event_processing_params"
                 ),

--- a/gw-siren-pipeline/tests/unit/test_config_multi_event.py
+++ b/gw-siren-pipeline/tests/unit/test_config_multi_event.py
@@ -46,9 +46,9 @@ def test_full_multi_event_config(tmp_path):
             run_label: run1
             base_output_directory: out/
             candidate_galaxy_cache_dir: cache_gal/
+            gw_posteriors_cache_dir: gw_cache/
           events_to_combine:
             - event_id: EV1
-              gw_dl_samples_path: dl.npy
             - event_id: EV2
           priors:
             H0: {min: 50.0, max: 100.0}
@@ -76,6 +76,7 @@ def test_full_multi_event_config(tmp_path):
     assert me is not None
     assert me.run_settings.run_label == "run1"
     assert me.run_settings.candidate_galaxy_cache_dir == "cache_gal/"
+    assert me.run_settings.gw_posteriors_cache_dir == "gw_cache/"
     assert len(me.events_to_combine) == 2
     assert me.priors["H0"].max == 100.0
     assert me.mcmc.n_steps == 20

--- a/gw-siren-pipeline/tests/unit/test_multi_event_data_manager.py
+++ b/gw-siren-pipeline/tests/unit/test_multi_event_data_manager.py
@@ -8,6 +8,7 @@ from gwsiren.multi_event_data_manager import (
     load_multi_event_config,
     prepare_event_data,
     EventDataPackage,
+    _load_or_fetch_gw_posteriors,
 )
 from gwsiren.config import Config, MultiEventAnalysisSettings, MERunSettings
 from gwsiren.pipeline import (
@@ -23,7 +24,6 @@ def test_load_multi_event_config(tmp_path):
         """
         events_to_combine:
           - event_id: EV1
-            gw_dl_samples_path: dl1.npy
           - event_id: EV2
         """
     )
@@ -39,16 +39,22 @@ def test_load_multi_event_config(tmp_path):
 
 def test_prepare_event_data_loads_files(tmp_path, mock_config, monkeypatch):
     dl = np.array([1.0, 2.0])
+    ra = np.array([10.0, 11.0])
+    dec = np.array([-1.0, -2.0])
     df = pd.DataFrame({"z": [0.01], "mass_proxy": [1.0], "z_err": [0.001]})
-    dl_path = tmp_path / "dl.npy"
     cache_dir = tmp_path / "cache"
+    gw_cache = tmp_path / "gw"
     cache_dir.mkdir()
+    gw_cache.mkdir()
     cache_file = cache_dir / "EV1_cat_glade+_n128_cdf0.9_zfb0.05.csv"
-    np.save(dl_path, dl)
+    np.savez(gw_cache / "EV1_gw_posteriors.npz", dl=dl, ra=ra, dec=dec)
     df.to_csv(cache_file, index=False)
 
     me_cfg = MultiEventAnalysisSettings(
-        run_settings=MERunSettings(candidate_galaxy_cache_dir=str(cache_dir))
+        run_settings=MERunSettings(
+            candidate_galaxy_cache_dir=str(cache_dir),
+            gw_posteriors_cache_dir=str(gw_cache),
+        )
     )
     new_cfg = Config(
         catalog=mock_config.catalog,
@@ -60,10 +66,7 @@ def test_prepare_event_data_loads_files(tmp_path, mock_config, monkeypatch):
     )
     monkeypatch.setattr("gwsiren.multi_event_data_manager.CONFIG", new_cfg)
 
-    cfg = {
-        "event_id": "EV1",
-        "gw_dl_samples_path": str(dl_path),
-    }
+    cfg = {"event_id": "EV1"}
 
     package = prepare_event_data(cfg)
 
@@ -79,10 +82,18 @@ def test_prepare_event_data_generation_path(tmp_path, mock_config, monkeypatch, 
         "gwsiren.multi_event_data_manager.run_full_analysis",
         return_value=results,
     )
+    gw_mock = mocker.patch(
+        "gwsiren.multi_event_data_manager._load_or_fetch_gw_posteriors",
+        return_value=(results["dL_samples"], np.array([]), np.array([])),
+    )
 
     cache_dir = tmp_path / "cache"
+    gw_cache = tmp_path / "gw"
     me_cfg = MultiEventAnalysisSettings(
-        run_settings=MERunSettings(candidate_galaxy_cache_dir=str(cache_dir))
+        run_settings=MERunSettings(
+            candidate_galaxy_cache_dir=str(cache_dir),
+            gw_posteriors_cache_dir=str(gw_cache),
+        )
     )
     new_cfg = Config(
         catalog=mock_config.catalog,
@@ -108,6 +119,7 @@ def test_prepare_event_data_generation_path(tmp_path, mock_config, monkeypatch, 
     )
     assert np.allclose(package.dl_samples, results["dL_samples"])
     pd.testing.assert_frame_equal(package.candidate_galaxies_df, df)
+    gw_mock.assert_called_once_with("EVGEN")
 
 
 def test_candidate_galaxy_cache(tmp_path, mock_config, mocker, monkeypatch):
@@ -117,10 +129,18 @@ def test_candidate_galaxy_cache(tmp_path, mock_config, mocker, monkeypatch):
         "gwsiren.multi_event_data_manager.run_full_analysis",
         return_value=results,
     )
+    gw_mock = mocker.patch(
+        "gwsiren.multi_event_data_manager._load_or_fetch_gw_posteriors",
+        return_value=(results["dL_samples"], np.array([]), np.array([])),
+    )
 
     cache_dir = tmp_path / "cache"
+    gw_cache = tmp_path / "gw"
     me_cfg = MultiEventAnalysisSettings(
-        run_settings=MERunSettings(candidate_galaxy_cache_dir=str(cache_dir))
+        run_settings=MERunSettings(
+            candidate_galaxy_cache_dir=str(cache_dir),
+            gw_posteriors_cache_dir=str(gw_cache),
+        )
     )
     new_cfg = Config(
         catalog=mock_config.catalog,
@@ -132,9 +152,7 @@ def test_candidate_galaxy_cache(tmp_path, mock_config, mocker, monkeypatch):
     )
     monkeypatch.setattr("gwsiren.multi_event_data_manager.CONFIG", new_cfg)
 
-    dl_path = tmp_path / "dl.npy"
-    np.save(dl_path, results["dL_samples"])
-    cfg = {"event_id": "EVX", "gw_dl_samples_path": str(dl_path)}
+    cfg = {"event_id": "EVX"}
 
     # First call generates and writes to cache
     package1 = prepare_event_data(cfg)
@@ -146,6 +164,71 @@ def test_candidate_galaxy_cache(tmp_path, mock_config, mocker, monkeypatch):
     run_mock.reset_mock()
     package2 = prepare_event_data(cfg)
     run_mock.assert_not_called()
+    gw_mock.assert_called()
 
     pd.testing.assert_frame_equal(package1.candidate_galaxies_df, df)
     pd.testing.assert_frame_equal(package2.candidate_galaxies_df, df)
+
+
+def test_gw_posteriors_cache_hit(tmp_path, mock_config, mocker, monkeypatch):
+    gw_dir = tmp_path / "gw"
+    gw_dir.mkdir()
+    np.savez(gw_dir / "EV1_gw_posteriors.npz", dl=np.array([1.0]), ra=np.array([0.1]), dec=np.array([-0.1]))
+
+    me_cfg = MultiEventAnalysisSettings(
+        run_settings=MERunSettings(gw_posteriors_cache_dir=str(gw_dir))
+    )
+    new_cfg = Config(
+        catalog=mock_config.catalog,
+        skymap=mock_config.skymap,
+        mcmc=mock_config.mcmc,
+        cosmology=mock_config.cosmology,
+        fetcher=mock_config.fetcher,
+        multi_event_analysis=me_cfg,
+    )
+    monkeypatch.setattr("gwsiren.multi_event_data_manager.CONFIG", new_cfg)
+    fetch_mock = mocker.patch("gwsiren.multi_event_data_manager.fetch_candidate_data")
+    dl, ra, dec = _load_or_fetch_gw_posteriors("EV1")
+    assert np.allclose(dl, [1.0])
+    assert np.allclose(ra, [0.1])
+    assert np.allclose(dec, [-0.1])
+    fetch_mock.assert_not_called()
+
+
+def test_gw_posteriors_cache_miss(tmp_path, mock_config, mocker, monkeypatch):
+    gw_dir = tmp_path / "gw"
+    gw_dir.mkdir()
+    pes_dir = tmp_path / "pes"
+
+    monkeypatch.setattr(
+        "gwsiren.multi_event_data_manager.configure_astropy_cache",
+        lambda *_args, **_kw: str(pes_dir),
+    )
+    fetch_mock = mocker.patch(
+        "gwsiren.multi_event_data_manager.fetch_candidate_data",
+        return_value=(True, "obj"),
+    )
+    extract_mock = mocker.patch(
+        "gwsiren.multi_event_data_manager.extract_gw_event_parameters",
+        return_value=(np.array([2.0]), np.array([0.2]), np.array([-0.2])),
+    )
+
+    me_cfg = MultiEventAnalysisSettings(
+        run_settings=MERunSettings(gw_posteriors_cache_dir=str(gw_dir))
+    )
+    new_cfg = Config(
+        catalog=mock_config.catalog,
+        skymap=mock_config.skymap,
+        mcmc=mock_config.mcmc,
+        cosmology=mock_config.cosmology,
+        fetcher=mock_config.fetcher,
+        multi_event_analysis=me_cfg,
+    )
+    monkeypatch.setattr("gwsiren.multi_event_data_manager.CONFIG", new_cfg)
+
+    dl, ra, dec = _load_or_fetch_gw_posteriors("EV2")
+
+    assert np.allclose(dl, [2.0])
+    assert (gw_dir / "EV2_gw_posteriors.npz").exists()
+    fetch_mock.assert_called_once()
+    extract_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- support caching of extracted GW posterior samples
- configure cache directory via `gw_posteriors_cache_dir`
- remove obsolete `gw_dl_samples_path` field
- load GW posterior samples from cache in multi-event manager
- update tests for new caching behaviour

## Testing
- `pytest -q`