### PR TITLE
Add backend selection helper and tests

### DIFF
--- a/gw-siren-pipeline/gwsiren/__init__.py
+++ b/gw-siren-pipeline/gwsiren/__init__.py
@@ -22,6 +22,7 @@ from .multi_event_data_manager import (
     prepare_all_event_data,
 )
 from .combined_likelihood import CombinedLogLikelihood
+from .backends import get_xp
 
 __all__ = [
     "Config",
@@ -44,4 +45,5 @@ __all__ = [
     "run_global_mcmc",
     "process_global_mcmc_samples",
     "save_global_samples",
+    "get_xp",
 ]

--- a/gw-siren-pipeline/gwsiren/backends.py
+++ b/gw-siren-pipeline/gwsiren/backends.py
@@ -1,0 +1,81 @@
+"""Utilities for selecting the numerical backend used by gwsiren."""
+
+from __future__ import annotations
+
+import logging
+import numpy
+
+logger = logging.getLogger(__name__)
+
+
+def get_xp(preferred_backend: str = "auto") -> tuple[object, str]:
+    """Determine which numerical module to use.
+
+    This inspects the requested backend, the availability of JAX, and whether a
+    GPU is visible. It returns the numerical module to use and a string
+    identifier.
+
+    Args:
+        preferred_backend: Desired backend. ``"auto"`` prefers JAX with GPU if
+            available, otherwise NumPy. ``"numpy"`` forces NumPy. ``"jax"`` forces
+            JAX even if only the CPU is available.
+
+    Returns:
+        tuple[object, str]: ``(module, name)`` where ``name`` is ``"numpy"`` or
+        ``"jax"``.
+    """
+
+    backend = preferred_backend.lower()
+
+    if backend == "numpy":
+        logger.info("User selected NumPy backend.")
+        return numpy, "numpy"
+
+    # Attempt to import JAX
+    try:
+        import jax  # type: ignore
+        import jax.numpy as jnp  # type: ignore
+    except ImportError:
+        if backend == "jax":
+            logger.warning(
+                "JAX backend was requested, but JAX is not installed. Falling back to NumPy."
+            )
+        else:
+            logger.info("JAX not found. Defaulting to NumPy backend.")
+        return numpy, "numpy"
+
+    # JAX successfully imported
+    try:
+        devices = jax.devices()  # type: ignore[attr-defined]
+        has_gpu = any(
+            d.platform.lower() in ["gpu", "metal"]
+            or "gpu" in getattr(d, "device_kind", "").lower()
+            for d in devices
+        )
+    except Exception as exc:  # pragma: no cover - unlikely
+        logger.warning(
+            "Could not reliably determine JAX device types: %s. Assuming no specialized hardware (GPU/TPU) for JAX.",
+            exc,
+        )
+        has_gpu = False
+
+    if backend == "jax":
+        if has_gpu:
+            logger.info("JAX backend selected by user. Using JAX on GPU.")
+        else:
+            logger.info(
+                "JAX backend selected by user. Using JAX on CPU (No GPU detected/available to JAX)."
+            )
+        return jnp, "jax"  # type: ignore[return-value]
+
+    if backend == "auto":
+        if has_gpu:
+            logger.info("Auto backend selection: JAX available with GPU. Using JAX on GPU.")
+            return jnp, "jax"  # type: ignore[return-value]
+        logger.info(
+            "Auto backend selection: JAX is available, but no GPU detected. Falling back to NumPy as per current policy for 'auto' mode."
+        )
+        return numpy, "numpy"
+
+    logger.warning("Unexpected condition in backend selection. Defaulting to NumPy.")
+    return numpy, "numpy"

--- a/gw-siren-pipeline/tests/unit/test_backends.py
+++ b/gw-siren-pipeline/tests/unit/test_backends.py
@@ -1,0 +1,80 @@
+import builtins
+import sys
+import types
+
+import pytest
+
+from gwsiren.backends import get_xp
+
+
+class DummyDevice:
+    def __init__(self, platform="cpu", device_kind="CPU"):
+        self.platform = platform
+        self.device_kind = device_kind
+
+
+def make_jax_stub(has_gpu: bool):
+    jnp = types.ModuleType("jax.numpy")
+
+    class JaxModule(types.ModuleType):
+        def devices(self):
+            if has_gpu:
+                return [DummyDevice(platform="gpu", device_kind="GPU")]
+            return [DummyDevice(platform="cpu", device_kind="CPU")]
+
+    jax_mod = JaxModule("jax")
+    jax_mod.numpy = jnp
+    return jax_mod, jnp
+
+
+def test_get_xp_numpy_backend(caplog):
+    caplog.set_level("INFO")
+    xp, name = get_xp("numpy")
+    assert name == "numpy"
+    assert xp is sys.modules["numpy"]
+    assert any("NumPy backend" in rec.message for rec in caplog.records)
+
+
+def test_get_xp_jax_not_installed(monkeypatch, caplog):
+    caplog.set_level("INFO")
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("jax"):
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    xp, name = get_xp("jax")
+
+    assert name == "numpy"
+    assert xp is sys.modules["numpy"]
+    assert any("not installed" in rec.message for rec in caplog.records)
+
+
+def test_get_xp_auto_with_jax_cpu(monkeypatch, caplog):
+    caplog.set_level("INFO")
+    jax_mod, jnp_mod = make_jax_stub(has_gpu=False)
+    monkeypatch.setitem(sys.modules, "jax", jax_mod)
+    monkeypatch.setitem(sys.modules, "jax.numpy", jnp_mod)
+
+    xp, name = get_xp("auto")
+
+    assert name == "numpy"
+    assert xp is sys.modules["numpy"]
+    assert any("no gpu" in rec.message.lower() for rec in caplog.records)
+
+
+def test_get_xp_auto_with_jax_gpu(monkeypatch, caplog):
+    caplog.set_level("INFO")
+    jax_mod, jnp_mod = make_jax_stub(has_gpu=True)
+    monkeypatch.setitem(sys.modules, "jax", jax_mod)
+    monkeypatch.setitem(sys.modules, "jax.numpy", jnp_mod)
+
+    xp, name = get_xp("auto")
+
+    assert name == "jax"
+    assert xp is jnp_mod
+    assert any("using jax on gpu" in rec.message.lower() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `get_xp` backend selection utility in `gwsiren.backends`
- expose `get_xp` from package `__init__`
- unit tests for backend selection helper

## Testing
- `pytest -q`