### PR TITLE
Add JIT-friendly log_gaussian utility

### DIFF
--- a/gw-siren-pipeline/gwsiren/__init__.py
+++ b/gw-siren-pipeline/gwsiren/__init__.py
@@ -22,6 +22,7 @@ from .multi_event_data_manager import (
     prepare_all_event_data,
 )
 from .combined_likelihood import CombinedLogLikelihood
+from .backends import log_gaussian
 
 __all__ = [
     "Config",
@@ -41,6 +42,7 @@ __all__ = [
     "prepare_event_data",
     "prepare_all_event_data",
     "CombinedLogLikelihood",
+    "log_gaussian",
     "run_global_mcmc",
     "process_global_mcmc_samples",
     "save_global_samples",

--- a/gw-siren-pipeline/gwsiren/backends.py
+++ b/gw-siren-pipeline/gwsiren/backends.py
@@ -1,0 +1,35 @@
+"""Backend-agnostic numerical utilities for gwsiren."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def log_gaussian(
+    xp: Any,
+    x: Any,
+    mu: Any,
+    sigma: Any,
+) -> Any:
+    """Compute the log of a Gaussian probability density function.
+
+    This implementation is backend agnostic and works with ``numpy`` or
+    ``jax.numpy`` by passing the appropriate module as ``xp``.
+
+    Args:
+        xp: Numerical backend module (``numpy`` or ``jax.numpy``).
+        x: Point or array at which to evaluate the log PDF.
+        mu: Mean of the distribution.
+        sigma: Standard deviation of the distribution.
+
+    Returns:
+        The log probability density evaluated at ``x``.
+    """
+    term1 = -0.5 * xp.log(2.0 * xp.pi)
+    term2 = -xp.log(sigma)
+    term3 = -0.5 * xp.square((x - mu) / sigma)
+    return term1 + term2 + term3
+

--- a/gw-siren-pipeline/tests/unit/test_backends.py
+++ b/gw-siren-pipeline/tests/unit/test_backends.py
@@ -1,0 +1,29 @@
+import numpy as np
+from scipy.stats import norm
+
+from gwsiren.backends import log_gaussian
+
+
+def test_log_gaussian_scalar():
+    x, mu, sigma = 1.0, 0.0, 1.0
+    expected = norm.logpdf(x, loc=mu, scale=sigma)
+    actual = log_gaussian(np, x, mu, sigma)
+    np.testing.assert_allclose(actual, expected, rtol=1e-9)
+
+
+def test_log_gaussian_array():
+    x = np.array([1.0, 2.0, 0.5])
+    mu = np.array([0.0, 2.5, 0.5])
+    sigma = np.array([1.0, 0.5, 2.0])
+    expected = norm.logpdf(x, loc=mu, scale=sigma)
+    actual = log_gaussian(np, x, mu, sigma)
+    np.testing.assert_allclose(actual, expected, rtol=1e-9)
+
+
+def test_log_gaussian_broadcast():
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    mu = np.array([0.0, 1.0])
+    sigma = 1.5
+    expected = norm.logpdf(x, loc=mu, scale=sigma)
+    actual = log_gaussian(np, x, mu, sigma)
+    np.testing.assert_allclose(actual, expected, rtol=1e-9)


### PR DESCRIPTION
## Summary
- implement a backend-agnostic `log_gaussian` function
- expose `log_gaussian` via `gwsiren.__init__`
- test numerical correctness of `log_gaussian`

## Testing
- `pytest -q`